### PR TITLE
fix aviation unit in GECO 2022: "gCO2/pkm" -> "tCO2/pkm"

### DIFF
--- a/R/prepare_geco_2022_scenario.R
+++ b/R/prepare_geco_2022_scenario.R
@@ -361,5 +361,8 @@ prepare_geco_2022_aviation_scenario <- function(geco_2022_aviation_raw) {
 
   out <- dplyr::mutate(out, year = as.double(.data$year))
 
+  # "raw" data mislables values as "gCO2/pkm"
+  out <- dplyr::mutate(out, units = "tCO2/pkm")
+
   dplyr::select(out, prepared_scenario_names())
 }

--- a/tests/testthat/_snaps/prepare_geco_2022_scenario.md
+++ b/tests/testthat/_snaps/prepare_geco_2022_scenario.md
@@ -20,8 +20,8 @@
       12 GECO2022 NDC_LTS   Global             Coal   Coal       Producti~ mtoe   2025
       13 GECO2022 Reference Global             Coal   Coal       Producti~ mtoe   2020
       14 GECO2022 Reference Global             Coal   Coal       Producti~ mtoe   2025
-      15 GECO2022 NDC_LTS   Global             Aviat~ Passenger  Emission~ gCO2~  2020
-      16 GECO2022 NDC_LTS   Global             Aviat~ Passenger  Emission~ gCO2~  2025
+      15 GECO2022 NDC_LTS   Global             Aviat~ Passenger  Emission~ tCO2~  2020
+      16 GECO2022 NDC_LTS   Global             Aviat~ Passenger  Emission~ tCO2~  2025
       17 GECO2022 1.5C      Global             Steel  <NA>       Emission~ tCO2~  2020
       18 GECO2022 1.5C      Global             Steel  <NA>       Emission~ tCO2~  2025
       # i 1 more variable: value <dbl>


### PR DESCRIPTION
- closes #23 (I think, because we don't currently have GECO 2021 in this repo)

now this works as expected (with proper input/output paths and `config` properly set)...
```r
source("../workflow.scenario.preparation/process_scenario_geco_2022.R")

pacta.data.validation::validate_intermediate_scenario_output(geco_2022)

waldo::compare(
  dplyr::mutate(
    dplyr::arrange(pacta.scenario.preparation::geco_2022, scenario, scenario_geography, sector, technology),
    units = ifelse(sector == "Aviation", "tCO2/pkm", units)
  ),
  dplyr::arrange(geco_2022, scenario, scenario_geography, sector, technology),
  tolerance = 1e-15
)
```