### PR TITLE
deal with the malformed CSV text from `IEA-EV-dataEVsalesCarsProjection-APS.csv`

### DIFF
--- a/R/prepare_weo_2022_scenario.R
+++ b/R/prepare_weo_2022_scenario.R
@@ -12,8 +12,9 @@
 #'   `WEO2022_NZE_SteelData.csv`.
 #' @param weo_2022_sales_aps_auto_raw A data frame containing a raw import of
 #'   `SalesAPS_rawdata.csv`.
-#' @param weo_2022_electric_sales_aps_auto_raw A data frame containing a raw
-#'   import of `IEA-EV-dataEV salesCarsProjection-APS.csv`.
+#' @param weo_2022_electric_sales_aps_auto_raw_text A vector of character
+#'   strings containing each line of a raw import of `IEA-EV-dataEV
+#'   salesCarsProjection-APS.csv`.
 #'
 #' @return A prepared WEO 2022 scenario data-frame.
 #'
@@ -27,7 +28,19 @@ prepare_weo_2022_scenario <- function(weo_2022_ext_data_regions_raw,
                                       weo_2022_nze_auto_raw,
                                       weo_2022_nze_steel_raw,
                                       weo_2022_sales_aps_auto_raw,
-                                      weo_2022_electric_sales_aps_auto_raw) {
+                                      weo_2022_electric_sales_aps_auto_raw_text) {
+  lines_to_fix <- 3:length(weo_2022_electric_sales_aps_auto_raw_text)
+  weo_2022_electric_sales_aps_auto_raw_text[lines_to_fix] <-
+    paste0(
+      weo_2022_electric_sales_aps_auto_raw_text[lines_to_fix],
+      ",https://www.iea.org/reports/global-ev-outlook-2022/executive-summary"
+    )
+  weo_2022_electric_sales_aps_auto_raw <-
+    readr::read_csv(
+      file = I(weo_2022_electric_sales_aps_auto_raw_text),
+      show_col_types = FALSE
+    )
+
   fossil_fuel <-
     weo_2022_fossil_fuels_raw %>%
     dplyr::filter(.data[["Variable"]] == "Supply")

--- a/man/prepare_weo_2022_scenario.Rd
+++ b/man/prepare_weo_2022_scenario.Rd
@@ -11,7 +11,7 @@ prepare_weo_2022_scenario(
   weo_2022_nze_auto_raw,
   weo_2022_nze_steel_raw,
   weo_2022_sales_aps_auto_raw,
-  weo_2022_electric_sales_aps_auto_raw
+  weo_2022_electric_sales_aps_auto_raw_text
 )
 }
 \arguments{
@@ -33,8 +33,8 @@ prepare_weo_2022_scenario(
 \item{weo_2022_sales_aps_auto_raw}{A data frame containing a raw import of
 \code{SalesAPS_rawdata.csv}.}
 
-\item{weo_2022_electric_sales_aps_auto_raw}{A data frame containing a raw
-import of \verb{IEA-EV-dataEV salesCarsProjection-APS.csv}.}
+\item{weo_2022_electric_sales_aps_auto_raw_text}{A vector of character
+strings containing each line of a raw import of \verb{IEA-EV-dataEV salesCarsProjection-APS.csv}.}
 }
 \value{
 A prepared WEO 2022 scenario data-frame.


### PR DESCRIPTION
This causes a breaking change in workflow.scenario.preparation that will be fixed by https://github.com/RMI-PACTA/workflow.scenario.preparation/pull/49

``` r
devtools::load_all()
#> ℹ Loading pacta.scenario.data.preparation

scenario_preparation_inputs_path <- "~/data/pactarawdata/scenario-sources"
scenario_preparation_outputs_path <- "~/data/pactadatadev/workflow-scenario-preparation-outputs"

config <- list(
  weo_2022_raw_path = "00Imported/WEO2022 extended data/WEO2022 extended data",
  weo_2022_ext_data_regions_raw_filepath = "raw_data_from_provider/used_in_pacta.scenario_preparation/WEO2022_Extended_Data_Regions.csv",
  weo_2022_ext_data_world_raw_filepath = "raw_data_from_provider/used_in_pacta.scenario_preparation/WEO2022_Extended_Data_World.csv",
  weo_2022_fossil_fuels_raw_filepath = "light_process/weo2022_fossilfuel_demand_supply.csv",
  weo_2022_nze_auto_raw_filepath = "processed_data/nze_may_2021_report_old_data/hard_process_auto/used/NZE2021_RawData_2050.xlsx",
  weo_2022_nze_steel_raw_filepath = "raw_data_from_provider/used_in_pacta.scenario_preparation/WEO2022_NZE_SteelData.csv",
  weo_2022_sales_aps_auto_raw_filepath = "raw_data_from_provider/used_in_pacta.scenario_preparation/SalesAPS_rawdata.csv",
  weo_2022_electric_sales_aps_auto_raw_filename = "raw_data_from_provider/used_in_pacta.scenario_preparation/IEA-EV-dataEV salesCarsProjection-APS.csv"
)
```

``` r

source("../workflow.scenario.preparation/process_scenario_weo_2022.R")

pacta.data.validation::validate_intermediate_scenario_output(weo_2022)

waldo::compare(
  dplyr::arrange(pacta.scenario.preparation::weo_2022, source, scenario, scenario_geography, sector, technology),
  weo_2022,
  tolerance = 1e-15
)
#> ✔ No differences

tail(weo_2022_electric_sales_aps_auto_raw_text)
#> [1] "World,Projection-APS,EV sales,Cars,BEV,2021,sales,4700000" 
#> [2] "World,Projection-APS,EV sales,Cars,PHEV,2021,sales,1900000"
#> [3] "World,Projection-APS,EV sales,Cars,BEV,2025,sales,14000000"
#> [4] "World,Projection-APS,EV sales,Cars,PHEV,2025,sales,4700000"
#> [5] "World,Projection-APS,EV sales,Cars,BEV,2030,sales,34000000"
#> [6] "World,Projection-APS,EV sales,Cars,PHEV,2030,sales,7000000"
length(weo_2022_electric_sales_aps_auto_raw_text)
#> [1] 49
```