### PR TITLE
include isf_2021 in dictionary

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -43,6 +43,7 @@ bridge_technologies <- function(data, technology_bridge) {
 dictionary_p4i_p4b <- function() {
   dplyr::tribble(
     ~p4i_label, ~p4b_label,
+    "ISF2021", "isf_2021",
     "WEO2022", "weo_2022",
     "GECO2022", "geco_2022",
     "GECO2023", "geco_2023",


### PR DESCRIPTION
- updates `dictionary_p4i_p4b()` to include all scenarios inherited either from `2022Q4` or `2023Q4` in the `config.yml` in `workflow.scenario.preparation`, see https://github.com/RMI-PACTA/workflow.scenario.preparation/blob/main/config.yml
- this ensures the workflow can produce appropriately formatted p4b scenario files for both time stamps