### PR TITLE
remove redundant data transformation

### DIFF
--- a/R/prepare_weo_2024_hybrid_in_ev_scenario.R
+++ b/R/prepare_weo_2024_hybrid_in_ev_scenario.R
@@ -142,8 +142,7 @@ weo_2024_extract_power <- function(weo_2024_ext_data_regions_raw,
     dplyr::filter(
       .data[["unit"]] == "GW",
       !(.data[["technology"]] %in% techs_out_of_pacta_scope)
-    ) %>%
-    dplyr::mutate(year = as.double(.data[["year"]]))
+    )
 
   weo_2024_power_regions_aps_baseline <-
     weo_2024_extended_regions %>%


### PR DESCRIPTION
this is redundant because the `year` values are already imported as doubles, and since this transformation is not done (or needed) anywhere else, it's a bit confusing to have it here